### PR TITLE
Use counter instead of meter

### DIFF
--- a/src/samplers/statsd.c
+++ b/src/samplers/statsd.c
@@ -194,8 +194,8 @@ int brubeck_statsd_msg_parse(struct brubeck_statsd_msg *msg, char *buffer, char 
 	{
 		switch (*buffer) {
 			case 'g': msg->type = BRUBECK_MT_GAUGE; break;
-			case 'c': msg->type = BRUBECK_MT_METER; break;
-			case 'C': msg->type = BRUBECK_MT_COUNTER; break;
+			case 'C': msg->type = BRUBECK_MT_METER; break;
+			case 'c': msg->type = BRUBECK_MT_COUNTER; break;
 			case 'h': msg->type = BRUBECK_MT_HISTO; break;
 			case 'm':
 					  ++buffer;


### PR DESCRIPTION
Using meter was causing us to aggregate 10 seconds worth of data before
sending to graphite, which was causing our metrics to appear 10x higher than
they actually were in the graphite UI. The statsd documentation states
that counters are a count of events per second averaged over 1 minute,
however brubeck was invalidating this by replacing counters with its own
meter type. This diff flips them back.