### PR TITLE
Divide meter sample value by sample_freq

### DIFF
--- a/src/metric.c
+++ b/src/metric.c
@@ -98,6 +98,8 @@ meter__sample(struct brubeck_metric *metric, brubeck_sample_cb sample, void *opa
 	}
 	pthread_spin_unlock(&metric->lock);
 
+	struct brubeck_backend *backend = (struct brubeck_backend *)opaque;
+	value /= (value_t)backend->sample_freq;
 	sample(metric->key, value, opaque);
 }
 

--- a/src/samplers/statsd.c
+++ b/src/samplers/statsd.c
@@ -194,8 +194,8 @@ int brubeck_statsd_msg_parse(struct brubeck_statsd_msg *msg, char *buffer, char 
 	{
 		switch (*buffer) {
 			case 'g': msg->type = BRUBECK_MT_GAUGE; break;
-			case 'C': msg->type = BRUBECK_MT_METER; break;
-			case 'c': msg->type = BRUBECK_MT_COUNTER; break;
+			case 'c': msg->type = BRUBECK_MT_METER; break;
+			case 'C': msg->type = BRUBECK_MT_COUNTER; break;
 			case 'h': msg->type = BRUBECK_MT_HISTO; break;
 			case 'm':
 					  ++buffer;


### PR DESCRIPTION
We don't want to over-report counter values so we need to divide by the
sample frequency to get a per-second value as stated in the statsd
documentation.